### PR TITLE
vim-patch:9.1.1115: [security]: use-after-free in str_to_reg()

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3721,9 +3721,15 @@ void ex_display(exarg_T *eap)
     get_clipboard(name, &yb, true);
 
     if (name == mb_tolower(redir_reg)
-        || (redir_reg == '"' && yb == y_previous)) {
+
+        || (vim_strchr("\"*+", redir_reg) != NULL &&
+
+            (yb == y_previous || yb == &y_regs[0]))) {
+
       continue;  // do not list register being written to, the
+
                  // pointer can be freed
+
     }
 
     if (yb->y_array != NULL) {


### PR DESCRIPTION
vim-patch:9.1.1115: [security]: use-after-free in str_to_reg()

Problem:  [security]: use-after-free in str_to_reg()
          (fizz-is-on-the-way)
Solution: when redirecting the :display command, check that one
          does not output to the register being displayed

vim/vim@777e7c2